### PR TITLE
Minor Updates including Affinity Support

### DIFF
--- a/.github/workflows/ansible-lint.yaml
+++ b/.github/workflows/ansible-lint.yaml
@@ -1,0 +1,19 @@
+# .github/workflows/ansible-lint.yml
+name: ansible-lint
+on:
+  pull_request:
+    branches: ["main"]
+jobs:
+  build:
+    name: Ansible Lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - name: Setup and Run ansible-lint
+        shell: bash
+        run: |
+          ./scripts/lint.sh

--- a/README.md
+++ b/README.md
@@ -166,6 +166,7 @@ Each host in the inventory file can use the variables listed in the table below.
 
 |Variable|Type|Required|Description|
 |:---|:---|:---|:---|
+|`affinity`|Object|False|This object is passed directly to `.spec.template.spec.affinity` in the corresponding `VirtualMachine` resource.|
 |`annotations`|Object|False|Annotations to be appeneded to the `VirtualMachineInstance`.|
 |`api_node_type`|String|True|Can be one of `master` or `worker`.|
 |`autoattach_memballon`|Boolean|False|Whether to attach the Memory balloon device to the virtual machine. If `autoattach_memballon` is not defined or `false`, the `autoattachMemBalloon` setting is ommited from the `VirtualMachine` spec.|

--- a/roles/kubevirt_disk/tasks/remove.yaml
+++ b/roles/kubevirt_disk/tasks/remove.yaml
@@ -2,6 +2,7 @@
 - name: Assert Variables are Defined
   ansible.builtin.assert:
     that:
+      - kubevirt_disk_name is defined
       - kubevirt_disk_vm_name is defined
       - kubevirt_disk_vm_namespace is defined
 

--- a/roles/o3_acm_create_infraenv/tasks/main.yaml
+++ b/roles/o3_acm_create_infraenv/tasks/main.yaml
@@ -1,4 +1,16 @@
 ---
+- name: Create InfraEnv Namespace
+  kubernetes.core.k8s:
+    api_key: "{{ k8s_auth_api_key }}"
+    host: "{{ k8s_auth_host }}"
+    resource_definition:
+      apiVersion: v1
+      kind: Namespace
+      metadata:
+        name: "{{ infra_env.namespace }}"
+      spec: {}
+    validate_certs: "{{ validate_certs }}"
+
 - name: Create InfraEnv Pull Secret
   kubernetes.core.k8s:
     api_key: "{{ k8s_auth_api_key }}"
@@ -74,21 +86,6 @@
     - infraenv_results.resources[0].status.conditions is defined
     - infraenv_results.resources[0].status.conditions | count >= 1
     - infraenv_results.resources[0] | json_query(_query) | first == "True"
-
-- name: Create ConfigMap for CA Certificate
-  kubernetes.core.k8s:
-    api_key: "{{ k8s_auth_api_key }}"
-    host: "{{ k8s_auth_host }}"
-    resource_definition:
-      apiVersion: v1
-      data:
-        ca.crt: |-
-          {{ additional_trust_bundle | trim }}
-      kind: ConfigMap
-      metadata:
-        name: iso-http-ca
-        namespace: "{{ infra_env.namespace }}"
-    validate_certs: "{{ validate_certs }}"
 
 - name: Set ISO Facts
   ansible.builtin.set_fact:

--- a/roles/o3_create_vms/tasks/main.yaml
+++ b/roles/o3_create_vms/tasks/main.yaml
@@ -37,6 +37,7 @@
     host: "{{ k8s_auth_host }}"
     kind: VirtualMachine
     label_selectors: "{{ _label_selector_key_list | zip(_label_selector_value_list) | map('join', ' = ') }}"
+    namespace: "{{ vm_namespace }}"
     validate_certs: "{{ validate_certs }}"
   register: vm_results
 

--- a/roles/o3_create_vms/templates/virtualmachine.yaml.j2
+++ b/roles/o3_create_vms/templates/virtualmachine.yaml.j2
@@ -3,6 +3,11 @@
 {% else -%}
   {% set vm_defaults = worker_defaults -%}
 {% endif -%}
+{% if hostvars[item].affinity is defined %}
+  {% set vm_affinity = hostvars[item].affinity %}
+{% elif vm_defaults.affinity is defined %}
+  {% set vm_affinity = vm_defaults.affinity %}
+{% endif %}
 ---
 apiVersion: kubevirt.io/v1
 kind: VirtualMachine
@@ -42,6 +47,10 @@ spec:
         {{ hostvars[item].labels | default(vm_defaults.labels, true) | to_nice_yaml(indent=2) | indent(8) | trim }}
       {% endif %}
     spec:
+      {% if vm_affinity is defined %}
+      affinity:
+        {{ vm_affinity | to_nice_yaml(indent=2) | indent(8) | trim }}
+      {% endif %}
       architecture: amd64
       domain:
         cpu:

--- a/roles/o3_first_boot/tasks/main.yaml
+++ b/roles/o3_first_boot/tasks/main.yaml
@@ -1,4 +1,19 @@
 ---
+- name: Create ConfigMap for CA Certificate
+  kubernetes.core.k8s:
+    api_key: "{{ k8s_auth_api_key }}"
+    host: "{{ k8s_auth_host }}"
+    resource_definition:
+      apiVersion: v1
+      data:
+        ca.crt: |-
+          {{ additional_trust_bundle | trim }}
+      kind: ConfigMap
+      metadata:
+        name: iso-http-ca
+        namespace: "{{ infra_env.namespace }}"
+    validate_certs: "{{ validate_certs }}"
+
 - name: Create Discovery ISO DataVolume from HTTP Source
   kubernetes.core.k8s:
     api_key: "{{ k8s_auth_api_key }}"

--- a/scripts/lint.sh
+++ b/scripts/lint.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+TMP_DIRECTORY=/tmp
+
+if [ ! -z "${GITHUB_ACTIONS}" ]; then
+  TMP_DIRECTORY=$RUNNER_TEMP
+fi
+
+python -m venv $TMP_DIRECTORY/temp-venv
+. $TMP_DIRECTORY/temp-venv/bin/activate
+
+if [ -z "${VIRTUAL_ENV}" ]; then
+  echo "Could not determine if we are running in a virtual environment...bailing."
+  exit 1
+fi
+
+pip install -U -r requirements.txt
+
+# ansible-galaxy collection install -r collections/requirements.yaml
+
+ansible-lint -f full --profile production -v
+
+if [ -z "${GITHUB_ACTIONS}" ]; then
+  rm -rf /tmp/temp-venv
+fi


### PR DESCRIPTION
* Adding support for `affinity` property in VM or host defaults. The object will be passed directly to `.spec.template.spec.affinity`
* Moved ISO CA `ConfigMap` to virtualization cluster (needs to be with `VirtualMachine` resources)
* Added missing namespace field to `VirtualMachine` query
* Adding check for `kubevirt_disk_name` in `kubevirt_disk` remove tasks
* Adding linter to repository