### PR TITLE
Fortinet FortiGate Virtual Server Support

### DIFF
--- a/ansible.cfg
+++ b/ansible.cfg
@@ -1,9 +1,6 @@
-[connection]
-pipelining = False
-
 [defaults]
-callbacks_enabled = profile_tasks
-collections_path = collections/ansible_collections
-host_key_checking = False
-retry_files_enabled = False
-roles_path = roles:../uc2-gitops/ansible/roles
+callbacks_enabled=profile_tasks
+collections_path=collections
+host_key_checking=False
+retry_files_enabled=False
+roles_path=roles

--- a/collections/requirements.yaml
+++ b/collections/requirements.yaml
@@ -3,6 +3,8 @@ collections:
     source: https://galaxy.ansible.com
   - name: community.general
     source: https://galaxy.ansible.com
+  - name: fortinet.fortios
+    source: https://galaxy.ansible.com
   - name: kubernetes.core
     source: https://galaxy.ansible.com
   - name: kubevirt.core

--- a/roles/fortigate/defaults/main.yaml
+++ b/roles/fortigate/defaults/main.yaml
@@ -1,0 +1,37 @@
+---
+policy_action: accept
+policy_anti_replay: enable
+policy_auto_asic_offload: enable
+policy_firewall_session_dirty: check-all
+policy_fixedport: disable
+policy_inbound: disable
+policy_inspection_mode: flow
+policy_ippool: disable
+policy_logtraffic: utm
+policy_logtraffic_start: disable
+policy_match_vip: enable
+policy_match_vip_only: disable
+policy_nat: enable
+policy_nat46: disable
+policy_nat64: disable
+policy_natinbound: disable
+policy_natip: 0.0.0.0 0.0.0.0
+policy_natoutbound: disable
+policy_np_acceleration: enable
+policy_outbound: enable
+# Setting policyid to 0 will assign the latest available number for the object
+policy_policyid: 0
+policy_port_preserve: enable
+policy_schedule: always
+policy_status: enable
+realserver_healthcheck: vip
+realserver_holddown_interval: 300
+realserver_max_connections: 0
+realserver_status: active
+realserver_translate_host: enable
+realserver_type: ip
+realserver_weight: 1
+vip_extintf: any
+vip_ldb_method: round-robin
+vip_server_type: tcp
+vip_type: server-load-balance

--- a/roles/fortigate/tasks/openshift.yaml
+++ b/roles/fortigate/tasks/openshift.yaml
@@ -1,0 +1,23 @@
+---
+- name: Validate Required Variables
+  ansible.builtin.assert:
+    that:
+      - acm is defined
+      - acm.cluster_name is defined
+      - fortigate_firewall_policies is defined
+      - fortigate_virtual_servers is defined
+      - provision_group is defined
+
+- name: Create Virtual Servers
+  ansible.builtin.include_tasks:
+    file: virtual-server.yaml
+  loop: "{{ fortigate_virtual_servers }}"
+  loop_control:
+    label: "{{ item.name }}"
+
+- name: Create Firewall Policies
+  ansible.builtin.include_tasks:
+    file: policy.yaml
+  loop: "{{ fortigate_firewall_policies }}"
+  loop_control:
+    label: "{{ item.name }}"

--- a/roles/fortigate/tasks/policy.yaml
+++ b/roles/fortigate/tasks/policy.yaml
@@ -1,0 +1,56 @@
+---
+- name: Get List of Virtual Servers and Reset _dstaddr
+  ansible.builtin.set_fact:
+    _dstaddr: []
+    _virtual_servers: "{{ fortigate_virtual_servers | json_query('[].name') }}"
+
+- name: Debug _virtual_servers
+  ansible.builtin.debug:
+    var: _virtual_servers
+
+- name: Build _dstaddr List
+  ansible.builtin.set_fact:
+    _dstaddr: "{{ _dstaddr | default([]) + [{'name': virtual_server_name}] }}"
+  loop: "{{ _virtual_servers }}"
+  loop_control:
+    loop_var: virtual_server_name
+
+- name: Debug _dstaddr
+  ansible.builtin.debug:
+    var: _dstaddr
+
+- name: "Create Firewall Policy {{ item.name }}"
+  fortinet.fortios.fortios_firewall_policy:
+    firewall_policy:
+      action: "{{ item.action | default(fortigate_firewall_policy_defaults.action) | default(policy_action) }}"
+      anti_replay: "{{ item.anti_replay | default(fortigate_firewall_policy_defaults.anti_replay) | default(policy_anti_replay) }}"
+      auto_asic_offload: "{{ item.auto_asic_offload | default(fortigate_firewall_policy_defaults.anti_replay) | default(policy_auto_asic_offload) }}"
+      comments: "Created by Ansible on {{ now(utc=true, fmt='%Y-%m-%d %H:%M:%S UTC') }} for cluster {{ acm.cluster_name }}"
+      dstaddr: "{{ _dstaddr }}"
+      dstintf: "{{ item.dstintf | default(fortigate_firewall_policy_defaults.dstintf) }}"
+      firewall_session_dirty: "{{ item.firewall_session_dirty | default(fortigate_firewall_policy_defaults.firewall_session_dirty) | default(policy_firewall_session_dirty) }}"
+      fixedport: "{{ item.fixedport | default(fortigate_firewall_policy_defaults.fixedport) | default(policy_fixedport) }}"
+      groups: "{{ item.groups | default(fortigate_firewall_policy_defaults.groups) | default(omit) }}"
+      inbound: "{{ item.inbound | default(fortigate_firewall_policy_defaults.inbound) | default(policy_inbound) }}"
+      inspection_mode: "{{ item.inspection_mode | default(fortigate_firewall_policy_defaults.inspection_mode) | default(policy_inspection_mode) }}"
+      ippool: "{{ item.ippool | default(fortigate_firewall_policy_defaults.ippool) | default(policy_ippool) }}"
+      logtraffic: "{{ item.logtraffic | default(fortigate_firewall_policy_defaults.logtraffic) | default(policy_logtraffic) }}"
+      match_vip: "{{ item.match_vip | default(fortigate_firewall_policy_defaults.match_vip) | default(policy_match_vip) }}"
+      match_vip_only: "{{ item.match_vip_only | default(fortigate_firewall_policy_defaults.match_vip_only) | default(policy_match_vip_only) }}"
+      name: "{{ item.name }}"
+      nat: "{{ item.nat | default(fortigate_firewall_policy_defaults.nat) | default(policy_nat) }}"
+      nat46: "{{ item.nat46 | default(fortigate_firewall_policy_defaults.nat46) | default(policy_nat46) }}"
+      nat64: "{{ item.nat64 | default(fortigate_firewall_policy_defaults.nat64) | default(policy_nat64) }}"
+      natinbound: "{{ item.natinbound | default(fortigate_firewall_policy_defaults.natinbound) | default(policy_natinbound) }}"
+      natip: "{{ item.natip | default(fortigate_firewall_policy_defaults.natip) | default(policy_natip) }}"
+      natoutbound: "{{ item.natoutbound | default(fortigate_firewall_policy_defaults.natoutbound) | default(policy_natoutbound) }}"
+      np_acceleration: "{{ item.np_acceleration | default(fortigate_firewall_policy_defaults.np_acceleration) | default(policy_np_acceleration) }}"
+      outbound: "{{ item.outbound | default(fortigate_firewall_policy_defaults.outbound) | default(policy_outbound) }}"
+      policyid: "{{ item.policyid | default(fortigate_firewall_policy_defaults.policyid) | default(policy_policyid) }}"
+      port_preserve: "{{ item.port_preserve | default(fortigate_firewall_policy_defaults.port_preserve) | default(policy_port_preserve) }}"
+      schedule: "{{ item.schedule | default(fortigate_firewall_policy_defaults.schedule) | default(policy_schedule) }}"
+      service: "{{ item.service | default(fortigate_firewall_policy_defaults.service) }}"
+      srcaddr: "{{ item.srcaddr | default(fortigate_firewall_policy_defaults.srcaddr) }}"
+      srcintf: "{{ item.srcintf | default(fortigate_firewall_policy_defaults.srcintf) }}"
+      status: "{{ item.status | default(policy_status) }}"
+    state: present

--- a/roles/fortigate/tasks/virtual-server.yaml
+++ b/roles/fortigate/tasks/virtual-server.yaml
@@ -1,0 +1,64 @@
+---
+- name: Get Backend IP List and Reset _realservers
+  ansible.builtin.set_fact:
+    _backend_ips: >-
+      {{
+        groups[provision_group] |
+          map('extract', hostvars) |
+          selectattr('api_node_type', 'equalto', item.api_node_type) |
+          map(attribute='ip') | list
+      }}
+    _realservers: []
+
+- name: Debug _backend_ips
+  ansible.builtin.debug:
+    msg: "{{ _backend_ips }}"
+
+- name: Build _realservers List
+  ansible.builtin.set_fact:
+    _realservers: >-
+      {{
+        _realservers | default([]) +
+        [
+          {
+            'address': item.address | default(''),
+            'client_ip': item.client_ip | default(''),
+            'healthcheck': item.healthcheck | default(realserver_healthcheck),
+            'holddown_interval': item.holddown_interval | default(realserver_holddown_interval),
+            'http_host': item.http_host | default(''),
+            'id': i + 1,
+            'ip': ip,
+            'max_connections': item.max_connections | default(realserver_max_connections),
+            'monitor': item.monitor,
+            'port': item.port,
+            'status': item.status | default(realserver_status),
+            'translate_host': item.translate_host | default(realserver_translate_host),
+            'type': item.type | default(realserver_type),
+            'weight': item.weight | default(realserver_weight)
+          }
+        ]
+      }}
+  loop: "{{ _backend_ips }}"
+  loop_control:
+    index_var: i
+    label: "Adding member id={{ i }}, ip:port={{ ip }}:{{ item.port }}"
+    loop_var: ip
+
+- name: Debug _realservers
+  ansible.builtin.debug:
+    var: _realservers
+
+- name: "Create Virtual Server {{ item.name }}"
+  fortinet.fortios.fortios_firewall_vip:
+    firewall_vip:
+      comment: "Created by Ansible on {{ now(utc=true, fmt='%Y-%m-%d %H:%M:%S UTC') }} for cluster {{ acm.cluster_name }}"
+      extintf: "{{ item.extintf | default(vip_extintf) }}"
+      extip: "{{ item.extip }}"
+      extport: "{{ item.extport | default(item.port) }}"
+      ldb_method: "{{ item.ldb_method | default(vip_ldb_method) }}"
+      monitor: "{{ item.monitor }}"
+      name: "{{ item.name }}"
+      realservers: "{{ _realservers }}"
+      server_type: "{{ item.server_type | default(vip_server_type) }}"
+      type: "{{ item.type | default(vip_type) }}"
+    state: present


### PR DESCRIPTION
## TODO
* Documentation (defer)
* Example playbook showing `connection: httpapi` and associated inventory/variable files. (defer)

## Completed
* Create virtual servers with members backed by cluster inventory filtered by `api_node_type` (either `worker` or `master`)
  * API virtual server points to all hosts with `api_node_type: master`
  * Ingress virtual server points to all hosts with `api_node_type: worker`
* Create firewall policies to allow traffic into VIPs and setup NAT